### PR TITLE
Fixed undefined index error

### DIFF
--- a/fields/class-livy-acf-field-zelda-v5.php
+++ b/fields/class-livy-acf-field-zelda-v5.php
@@ -399,7 +399,7 @@ if ( ! class_exists( 'livy_acf_field_zelda' ) ) :
 				/*
 				*  Email, if email is set
 				*/
-				if ( $type_options['email'] && is_string( $type_options['email'] ) ) {
+				if ( isset($type_options['email']) && $type_options['email'] && is_string( $type_options['email'] ) ) {
 					?>
                     <div class="acf-field-zelda__email acf-field-zelda__fieldWrap" data-zelda-type="email" hidden>
                         <label for="<?php echo esc_attr( $field['name'] ) ?>[email]"><?php echo $type_options['email']
@@ -413,7 +413,7 @@ if ( ! class_exists( 'livy_acf_field_zelda' ) ) :
 				/*
 				*  External, if external is set
 				*/
-				if ( $type_options['external'] && is_string( $type_options['external'] ) ) {
+				if ( isset($type_options['external']) && $type_options['external'] && is_string( $type_options['external'] ) ) {
 					?>
                     <div class="acf-field-zelda__external acf-field-zelda__fieldWrap" data-zelda-type="external" hidden>
                         <label for="<?php echo esc_attr( $field['name'] ) ?>[external]"><?php echo $type_options['external']


### PR DESCRIPTION
An undefined index error was displaying on post edit screen when either External or Email were not turned on as options under the ACF Field's settings.

Not sure if this is the best way of going about fixing the issue, but I simply added in "isset()" to the conditions for both $type_options presenting an issue and the error went away without affecting (so far) anything else negatively.

My version of WP is 5.2.1 and ACF 5.8.0

Hope this helps! Great plugin!
